### PR TITLE
fix: Move @types/aws-lambda from dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1663,9 +1663,10 @@
       }
     },
     "@types/aws-lambda": {
-      "version": "8.10.46",
-      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.46.tgz",
-      "integrity": "sha512-88E4Hlypo3AE40wslm7N4n09lCIJwgYJm5wsaA3/Vib1xqjC/ANePTaPRpPdj9NzBSpw7Tgon58qGMYEArx4oA=="
+      "version": "8.10.47",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.47.tgz",
+      "integrity": "sha512-FIZjS1alDbH7qFpJxghmyS2g7h+DJjBj6Qhf2F4Nkz4LR+alTSvThQEAR2j9yRt7qlxDDxK/EagXDCURRSxo8A==",
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.6",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "trailingComma": "es5"
   },
   "devDependencies": {
+    "@types/aws-lambda": "^8.10.47",
     "@types/jest": "^25.1.4",
     "husky": "^4.2.1",
     "lambda-tester": "^4.0.1",
@@ -41,7 +42,5 @@
     "tslib": "^1.11.1",
     "typescript": "^3.8.2"
   },
-  "dependencies": {
-    "@types/aws-lambda": "^8.10.46"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
I am using your package for a project and I noticed that `@types/aws-lambda`is in the dependencies. This is probably an error hence this small PR to change it.

