### PR TITLE
[05/11] Harden response and error handling

### DIFF
--- a/src/httpResponse.ts
+++ b/src/httpResponse.ts
@@ -67,7 +67,7 @@ export class HttpError extends Error {
       response.multiValueHeaders = this.multiValueHeaders;
     }
 
-    if (this.isBase64Encoded) {
+    if (typeof this.isBase64Encoded === 'boolean') {
       response.isBase64Encoded = this.isBase64Encoded;
     }
 
@@ -107,7 +107,7 @@ export function buildResponseObject<BodyType = any>({
     result.multiValueHeaders = multiValueHeaders;
   }
 
-  if (isBase64Encoded) {
+  if (typeof isBase64Encoded === 'boolean') {
     result.isBase64Encoded = isBase64Encoded;
   }
 

--- a/src/lambdas.ts
+++ b/src/lambdas.ts
@@ -54,14 +54,14 @@ export function lambdas<ResponseDataType = any, Shared = any>(
       if (isJsError) {
         console.log('processed js error', response);
 
-        return httpError({
+        response = httpError({
           statusCode: 500,
-          body: JSON.stringify({
+          body: {
             // @ts-ignore
             errorName: response.name,
             // @ts-ignore
             message: response.message,
-          }),
+          },
         });
       }
 
@@ -83,7 +83,7 @@ export function lambdas<ResponseDataType = any, Shared = any>(
         ...response,
       });
 
-      if (typeof result.body === 'object') {
+      if (typeof result.body !== 'string' && result.body !== undefined) {
         result.body = JSON.stringify(result.body);
       }
 

--- a/test/httpResponse.test.ts
+++ b/test/httpResponse.test.ts
@@ -7,7 +7,21 @@ import {
   HttpResponse,
 } from '../src/httpResponse';
 
-const { badRequest, internalError, notFound, unauthorized } = HttpResponse;
+const {
+  badRequest,
+  badGateway,
+  conflict,
+  forbidden,
+  gatewayTimeout,
+  internalError,
+  methodNotAllowed,
+  networkAuthenticationRequire,
+  notAcceptable,
+  notFound,
+  notImplemented,
+  serviceUnavailable,
+  unauthorized,
+} = HttpResponse;
 
 test('badRequest() should return an HTTPError', () => {
   const mockBody = { message: 'test' };
@@ -120,6 +134,25 @@ test('HttpError.toHttpResponse should return an plain object rather than an Erro
   expect(result.isBase64Encoded).toBeUndefined();
 });
 
+test('HttpError.toHttpResponse should preserve isBase64Encoded false', () => {
+  const err = new HttpError({
+    statusCode: 502,
+    body: 'plain text',
+    isBase64Encoded: false,
+  });
+
+  expect(err.toHttpResponse()).toEqual({
+    body: 'plain text',
+    headers: {
+      'Access-Control-Allow-Credentials': true,
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json',
+    },
+    isBase64Encoded: false,
+    statusCode: 502,
+  });
+});
+
 test('httpError should set default statusCode to 400', () => {
   const err = httpError({ body: { message: true } });
   expect(err.statusCode).toBe(400);
@@ -214,6 +247,25 @@ test('buildResponseObject should isBase64Encoded', () => {
   });
 });
 
+test('buildResponseObject should preserve isBase64Encoded false', () => {
+  const result = buildResponseObject({
+    statusCode: 300,
+    body: 'plain text',
+    isBase64Encoded: false,
+  });
+
+  expect(result).toEqual({
+    body: 'plain text',
+    headers: {
+      'Access-Control-Allow-Credentials': true,
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json',
+    },
+    isBase64Encoded: false,
+    statusCode: 300,
+  });
+});
+
 test('badRequest should set default statusCode to 400', () => {
   const res = badRequest({ message: true });
   expect(res.statusCode).toBe(400);
@@ -227,6 +279,24 @@ test('badRequest should set default statusCode to custom one', () => {
 test('badRequest should not change the body', () => {
   const res = badRequest({ message: true }, { statusCode: 500 });
   expect(res.body).toStrictEqual({ message: true });
+});
+
+test.each([
+  ['badRequest', badRequest, 400],
+  ['unauthorized', unauthorized, 401],
+  ['forbidden', forbidden, 403],
+  ['notFound', notFound, 404],
+  ['methodNotAllowed', methodNotAllowed, 405],
+  ['notAcceptable', notAcceptable, 406],
+  ['conflict', conflict, 409],
+  ['internalError', internalError, 500],
+  ['notImplemented', notImplemented, 501],
+  ['badGateway', badGateway, 502],
+  ['serviceUnavailable', serviceUnavailable, 503],
+  ['gatewayTimeout', gatewayTimeout, 504],
+  ['networkAuthenticationRequire', networkAuthenticationRequire, 511],
+])('%s should default to its statusCode', (_name, helper, statusCode) => {
+  expect(helper({ message: true }).statusCode).toBe(statusCode);
 });
 
 test('internalError should set default statusCode to 500', () => {

--- a/test/lambdaWrapper.onlyOne.errorPath.test.ts
+++ b/test/lambdaWrapper.onlyOne.errorPath.test.ts
@@ -47,6 +47,50 @@ it('should return error when returning httpError', async () => {
   });
 });
 
+it('should return a plain 500 response when throwing a JavaScript Error', async () => {
+  const testHandler = lambdas([
+    () => {
+      throw new Error('boom');
+    },
+  ]);
+
+  const response = await LambdaTester(testHandler).expectResult();
+
+  expect(response).toEqual({
+    statusCode: 500,
+    body: JSON.stringify({
+      errorName: 'Error',
+      message: 'boom',
+    }),
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': true,
+      'Content-Type': 'application/json',
+    },
+  });
+  expect(response).not.toBeInstanceOf(Error);
+});
+
+it('should keep thrown plain values as 400 error responses', async () => {
+  const testHandler = lambdas([
+    () => {
+      throw 'plain failure';
+    },
+  ]);
+
+  const response = await LambdaTester(testHandler).expectResult();
+
+  expect(response).toEqual({
+    statusCode: 400,
+    body: 'plain failure',
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': true,
+      'Content-Type': 'application/json',
+    },
+  });
+});
+
 it('should return success() run even when no middlewares is passing', async () => {
   const testHandler = lambdas();
 
@@ -116,5 +160,31 @@ test('statusCode from Promise.reject should be used', async () => {
       'Content-Type': 'application/json',
     },
     statusCode: 401,
+  });
+});
+
+test('explicit isBase64Encoded false should be preserved', async () => {
+  const testHandler = lambdas([
+    () => ({
+      statusCode: 200,
+      body: 'plain text',
+      headers: {
+        'Content-Type': 'text/plain',
+      },
+      isBase64Encoded: false,
+    }),
+  ]);
+
+  const response = await LambdaTester(testHandler).expectResult();
+
+  expect(response).toEqual({
+    statusCode: 200,
+    body: 'plain text',
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Credentials': true,
+      'Content-Type': 'text/plain',
+    },
+    isBase64Encoded: false,
   });
 });

--- a/test/lambdaWrapper.onlyOne.happyPath.test.ts
+++ b/test/lambdaWrapper.onlyOne.happyPath.test.ts
@@ -100,7 +100,7 @@ it('should return a string when returning a string', async () => {
   });
 });
 
-it('should return a number when returning a number', async () => {
+it('should return a JSON string when returning a number', async () => {
   const mockResponse = 8888;
 
   const testHandler = lambdas([() => mockResponse]);
@@ -108,7 +108,7 @@ it('should return a number when returning a number', async () => {
   const response = await LambdaTester(testHandler).expectResult();
 
   expect(response).toEqual({
-    body: mockResponse,
+    body: JSON.stringify(mockResponse),
     headers: {
       'Access-Control-Allow-Credentials': true,
       'Access-Control-Allow-Origin': '*',
@@ -118,7 +118,7 @@ it('should return a number when returning a number', async () => {
   });
 });
 
-it('should return a boolean when returning a boolean', async () => {
+it('should return a JSON string when returning a boolean', async () => {
   const mockResponse = true;
 
   const testHandler = lambdas([() => mockResponse]);
@@ -126,7 +126,25 @@ it('should return a boolean when returning a boolean', async () => {
   const response = await LambdaTester(testHandler).expectResult();
 
   expect(response).toEqual({
-    body: mockResponse,
+    body: JSON.stringify(mockResponse),
+    headers: {
+      'Access-Control-Allow-Credentials': true,
+      'Access-Control-Allow-Origin': '*',
+      'Content-Type': 'application/json',
+    },
+    statusCode: 200,
+  });
+});
+
+it('should return a JSON string when returning an array', async () => {
+  const mockResponse = ['a', 'b'];
+
+  const testHandler = lambdas([() => mockResponse]);
+
+  const response = await LambdaTester(testHandler).expectResult();
+
+  expect(response).toEqual({
+    body: JSON.stringify(mockResponse),
     headers: {
       'Access-Control-Allow-Credentials': true,
       'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
## Summary
- Return thrown JavaScript errors through the normal plain API Gateway response path.
- Preserve explicit `isBase64Encoded: false` in response helpers.
- Normalize final response body serialization and add focused coverage for helper shortcuts, plain thrown values, and edge cases.

## Validation
- `npm test -- --runInBand --watchman=false`
- `npm run build`