### PR TITLE
[08/11] Refresh CI and release flow

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,24 +1,70 @@
-name: Test Coveralls
+name: CI
 
-on: ['push', 'pull_request']
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
 
 jobs:
-  build:
-    name: Build
+  checks:
+    name: Node ${{ matrix.node-version }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22.x, 24.x]
+
     steps:
-      - name: Clone repository
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v6
 
-      - name: Use Node.js 18
-        uses: actions/setup-node@v1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v6
         with:
-          node-version: '18.x'
+          node-version: ${{ matrix.node-version }}
+          cache: npm
 
-      - run: npm ci --silent
-      - run: npm run coverage
+      - name: Install
+        run: npm ci
 
-      - name: Coveralls
-        uses: coverallsapp/github-action@master
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high
+
+      - name: Package smoke check
+        run: npm pack --dry-run
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: checks
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Coverage
+        run: npm run coverage
+
+      - name: Upload coverage to Coveralls
+        uses: coverallsapp/github-action@v2.3.7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,19 +4,40 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24.x
           registry-url: https://registry.npmjs.org/
-      - run: npm ci --silent
-      - run: npm run lint
-      - run: npm run test
-      - run: npm run build
-      - run: npm publish --access public
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Package smoke check
+        run: npm pack --dry-run
+
+      - name: Publish
+        run: npm publish --access public --provenance
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Summary
- Replaced Node 12 workflows with Node 22.x and 24.x CI coverage.
- Updated GitHub Actions to current tagged versions: checkout v6, setup-node v6, Coveralls action v2.3.7.
- Added install, lint, test, build, production audit, and package smoke checks.
- Tightened npm publish permissions and enabled provenance on publish.

Validation
- npm ci
- npm run lint
- npm run test
- npm run build
- npm audit --omit=dev --audit-level=high
- npm --cache /private/tmp/npm-cache pack --dry-run
- npm run coverage

Follow-up
- Full dev dependency audit still reports issues from the legacy TSDX toolchain and should be handled with the toolchain modernization work.