### PR TITLE
[06/11] Clean up trace and logging

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -12,6 +12,8 @@ import {
 } from './httpResponse';
 
 type ApiGatewayEvent = APIGatewayProxyEvent | APIGatewayProxyEventV2;
+type Logger = Pick<Console, 'log'>;
+type HeaderMap = { [name: string]: string | string[] | undefined };
 
 const isApiGatewayV2Event = (
   event: ApiGatewayEvent
@@ -21,6 +23,53 @@ const isApiGatewayV2Event = (
 type ResponseWithStatusCode = {
   statusCode?: unknown;
 };
+
+const redactedValue = '[REDACTED]';
+const sensitiveHeaderNames = [
+  'authorization',
+  'cookie',
+  'proxy-authorization',
+  'set-cookie',
+  'x-api-key',
+];
+
+const getHeader = (
+  headers: { [name: string]: string | undefined } | undefined,
+  headerName: string
+) => {
+  const safeHeaders = headers ?? {};
+  const lowerCaseHeaderName = headerName.toLowerCase();
+  const headerKey = Object.keys(safeHeaders).find(
+    key => key.toLowerCase() === lowerCaseHeaderName
+  );
+
+  return headerKey ? safeHeaders[headerKey] ?? '' : '';
+};
+
+const redactHeaders = (headers?: HeaderMap) => {
+  if (headers == null) {
+    return headers;
+  }
+
+  return Object.keys(headers).reduce((result, headerName) => {
+    const shouldRedact = sensitiveHeaderNames.includes(
+      headerName.toLowerCase()
+    );
+
+    return {
+      ...result,
+      [headerName]: shouldRedact ? redactedValue : headers[headerName],
+    };
+  }, {} as HeaderMap);
+};
+
+const redactEventForLogging = (event: ApiGatewayEvent) => ({
+  ...event,
+  headers: redactHeaders(event.headers),
+  ...('multiValueHeaders' in event
+    ? { multiValueHeaders: redactHeaders(event.multiValueHeaders) }
+    : {}),
+});
 
 export async function funcQueueExecutor<
   Shared,
@@ -57,21 +106,28 @@ export async function funcQueueExecutor<
 
 export const createTraceInfo = (event: ApiGatewayEvent, context: Context) => {
   if (isApiGatewayV2Event(event)) {
+    const domainName = event.requestContext.domainName ?? '';
+    const path = event.requestContext.http.path ?? '';
+
     return {
-      endpoint: event.requestContext.domainName,
+      endpoint: `${domainName}${path}`,
       routeKey: event.requestContext.routeKey,
       requestBody: event.body || '',
       requestMethod: event.requestContext.http.method,
       requestId: event.requestContext.requestId,
+      requestPath: path,
+      domainName,
     };
   } else {
+    const domainName = event.requestContext.domainName ?? '';
+    const path = event.requestContext.path ?? '';
+
     return {
-      endpoint:
-        event.requestContext.domainName ?? '' + event.requestContext.path,
+      endpoint: `${domainName}${path}`,
       requestBody: event.body || '',
       requestMethod: event.requestContext.httpMethod,
 
-      country: event.headers['CloudFront-Viewer-Country'] ?? '',
+      country: getHeader(event.headers, 'CloudFront-Viewer-Country'),
       lambdaRequestId: context.awsRequestId,
       logStreamName: context.logStreamName,
       logGroupName: context.logGroupName,
@@ -110,10 +166,14 @@ export const addTraceInfoToResponseBody = (
   };
 };
 
-export const logRequestInfo = (event: ApiGatewayEvent, context: Context) => {
-  console.log('Aws-Api-Gateway-Request-Id: ', event.requestContext.requestId);
-  console.log('EVENT: ', event);
-  console.log('CONTEXT: ', context);
+export const logRequestInfo = (
+  event: ApiGatewayEvent,
+  context: Context,
+  logger: Logger = console
+) => {
+  logger.log('Aws-Api-Gateway-Request-Id: ', event.requestContext.requestId);
+  logger.log('EVENT: ', redactEventForLogging(event));
+  logger.log('CONTEXT: ', context);
 };
 
 export const transformResponseToHttpResponse = (

--- a/test/lambdaWrapperConfig.test.ts
+++ b/test/lambdaWrapperConfig.test.ts
@@ -100,7 +100,18 @@ it('should log when config.logRequestInfo sets to true', async () => {
     'Aws-Api-Gateway-Request-Id: ',
     mockEvent.requestContext.requestId
   );
-  expect(consoleLogMock).toHaveBeenNthCalledWith(2, 'EVENT: ', mockEvent);
+  expect(consoleLogMock).toHaveBeenNthCalledWith(
+    2,
+    'EVENT: ',
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: '[REDACTED]',
+      }),
+      multiValueHeaders: expect.objectContaining({
+        Authorization: '[REDACTED]',
+      }),
+    })
+  );
   expect(consoleLogMock).toHaveBeenNthCalledWith(
     3,
     'CONTEXT: ',

--- a/test/testResources.ts
+++ b/test/testResources.ts
@@ -115,7 +115,9 @@ export const getMockHttpApiEvent = (): APIGatewayProxyEventV2 => ({
     accept: '*/*',
     authorization: 'Bearer ..4r----',
     'content-type': 'application/json',
+    'cloudfront-viewer-country': 'NZ',
     host: 'abc123.execute-api.us-east-1.amazonaws.com',
+    'x-api-key': 'secret-api-key',
   },
   queryStringParameters: {
     include: 'teams',

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,20 +1,9 @@
-import { createTraceInfo } from '../src/utils';
-import { getMockEvent, getMockContext } from './testResources';
-
-// export const createTraceInfo = (
-//     event: APIGatewayProxyEvent,
-//     context: Context
-//   ) => ({
-//     endpoint: event.requestContext.domainName ?? '' + event.requestContext.path,
-//     requestBody: event.body || '',
-//     requestMethod: event.requestContext.httpMethod,
-
-//     country: event.headers['CloudFront-Viewer-Country'] ?? '',
-//     lambdaRequestId: context.awsRequestId,
-//     logStreamName: context.logStreamName,
-//     logGroupName: context.logGroupName,
-//     apiGatewayId: event.requestContext.requestId,
-//   });
+import { createTraceInfo, logRequestInfo } from '../src/utils';
+import {
+  getMockEvent,
+  getMockHttpApiEvent,
+  getMockContext,
+} from './testResources';
 
 test('createTraceInfo should set event.requestContext.domainName to empty if there is none', () => {
   const mockEvent = getMockEvent();
@@ -26,6 +15,16 @@ test('createTraceInfo should set event.requestContext.domainName to empty if the
   expect(result.endpoint).toEqual(mockEvent.requestContext.path);
 });
 
+test('createTraceInfo should include domain and path in endpoint for v1 events', () => {
+  const mockEvent = getMockEvent();
+  const mockContext = getMockContext();
+  const result = createTraceInfo(mockEvent, mockContext);
+
+  expect(result.endpoint).toEqual(
+    `${mockEvent.requestContext.domainName}${mockEvent.requestContext.path}`
+  );
+});
+
 test('createTraceInfo should set country to empty if there is no CloudFront-Viewer-Country', () => {
   const mockEvent = getMockEvent();
   const mockContext = getMockContext();
@@ -34,4 +33,55 @@ test('createTraceInfo should set country to empty if there is no CloudFront-View
   const result = createTraceInfo(mockEvent, mockContext);
 
   expect(result.country).toEqual('');
+});
+
+test('createTraceInfo should read CloudFront-Viewer-Country case-insensitively', () => {
+  const mockEvent = getMockEvent();
+  const mockContext = getMockContext();
+
+  delete mockEvent.headers['CloudFront-Viewer-Country'];
+  mockEvent.headers['cloudfront-viewer-country'] = 'AU';
+
+  const result = createTraceInfo(mockEvent, mockContext);
+
+  expect(result.country).toEqual('AU');
+});
+
+test('createTraceInfo should include v2 route, request id, method, path, and domain', () => {
+  const mockEvent = getMockHttpApiEvent();
+  const mockContext = getMockContext();
+
+  const result = createTraceInfo(mockEvent, mockContext);
+
+  expect(result).toEqual({
+    endpoint: `${mockEvent.requestContext.domainName}${mockEvent.requestContext.http.path}`,
+    routeKey: mockEvent.requestContext.routeKey,
+    requestBody: mockEvent.body,
+    requestMethod: mockEvent.requestContext.http.method,
+    requestId: mockEvent.requestContext.requestId,
+    requestPath: mockEvent.requestContext.http.path,
+    domainName: mockEvent.requestContext.domainName,
+  });
+});
+
+test('logRequestInfo should redact sensitive headers and support an injectable logger', () => {
+  const mockEvent = getMockEvent();
+  const mockContext = getMockContext();
+  const logger = { log: jest.fn() };
+
+  logRequestInfo(mockEvent, mockContext, logger);
+
+  expect(logger.log).toBeCalledTimes(3);
+  expect(logger.log).toHaveBeenNthCalledWith(
+    2,
+    'EVENT: ',
+    expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: '[REDACTED]',
+      }),
+      multiValueHeaders: expect.objectContaining({
+        Authorization: '[REDACTED]',
+      }),
+    })
+  );
 });


### PR DESCRIPTION
## Summary
- Fix trace endpoint construction for REST and HTTP API events.
- Add HTTP API trace fields for route key, request id, method, path, and domain.
- Redact sensitive request headers in request logging and allow logger injection for focused tests.

## Validation
- npm test -- --runInBand --watchman=false
- npm run build