### PR TITLE
Remove push trigger from CI

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  push:
   pull_request:
   schedule:
     - cron: "17 6 * * 1"


### PR DESCRIPTION
## Summary

- Remove the `push` trigger from the CI workflow.
- Keep CI running for pull requests, plus the existing scheduled and manual runs.

## Validation

- Ran `git diff --check`.